### PR TITLE
Add Tools and Docs to navigation bar

### DIFF
--- a/src/lib/NavDropdownMenu.svelte
+++ b/src/lib/NavDropdownMenu.svelte
@@ -1,0 +1,57 @@
+<script>
+	export let name;
+	export let items;
+</script>
+
+<section class="mzp-c-menu-item">
+	{#each items as item}
+		<a href={item.url} class="mzp-c-menu-item-head">
+			<a href={item.url} class="mzp-c-menu-item-title">{item.name}</a>
+			<p class="mzp-c-menu-item-desc">
+				{#if item.description}
+					{item.description}
+				{/if}
+			</p>
+		</a>
+	{/each}
+</section>
+
+<style lang="scss">
+	@import './src/styles/protocol/css/components/_menu.scss';
+	@import './src/styles/protocol/css/components/_menu-item.scss';
+
+	.mzp-c-menu-item-title {
+		font-family: 'Zilla Slab', Inter, X-LocaleSpecific, sans-serif;
+		color: #000000;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+		font-size: 10px;
+		line-height: 1.08;
+		text-decoration: none;
+	}
+	.mzp-c-menu-item-desc {
+		font-size: 4px;
+		color: $color-marketing-gray-70;
+	}
+	.mzp-c-menu-item-head {
+		display: block;
+		text-decoration: none;
+		width: 45%;
+		padding: 5px;
+		&:hover {
+			border-radius: $border-radius-md;
+			box-shadow: $box-shadow-sm;
+			background-color: $color-marketing-gray-10;
+		}
+	}
+	.mzp-c-menu-item {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: center;
+		width: 200%;
+		&:hover {
+			box-shadow: none;
+		}
+	}
+</style>

--- a/src/lib/NavDropdownMenu.svelte
+++ b/src/lib/NavDropdownMenu.svelte
@@ -1,5 +1,4 @@
 <script>
-	export let name;
 	export let items;
 </script>
 

--- a/src/lib/Navigation.svelte
+++ b/src/lib/Navigation.svelte
@@ -1,86 +1,9 @@
 <script>
 	import NavDropdownMenu from '../lib/NavDropdownMenu.svelte';
-
-	const navigations = [
-		{
-			name: 'Tools',
-			items: [
-				{
-					name: 'Looker',
-					url: 'Looker',
-					description: `Mozilla's primary tool for analyzing data.`
-				},
-				{
-					name: 'Glean Aggregated Metrics Dashboard (GLAM)',
-					url: 'glam.telemetry.mozilla.org',
-					description: `An interactive dashboard that examines the distributions of values of specific individual telemetry metrics, over various dimensions.`
-				},
-				{
-					name: 'Experimenter',
-					description: `The central resource for A/B experiments and feature rollouts in Firefox Mobile and Desktop`,
-					url: 'https://experimenter.services.mozilla.com/?ordering=-latest_change&search=&status=Complete&firefox_channel=&firefox_version=&owner=&analysis_owner=&experiment_date_field=&date_range_after=&date_range_before='
-				},
-				{
-					name: 'sql.telemetry.mozilla.org (STMO)',
-					url: 'sql.telemetry.mozilla.org',
-					description: `Mozilla instance of Redash that allows for SQL-based exploratory analysis and visualization / dashboard construction.`
-				},
-				{
-					name: 'Nimbus',
-					url: 'https://experimenter.services.mozilla.com/nimbus/?tab=completed',
-					description: `Firefox's cross-platform experimentation tool.`
-				},
-				{
-					name: 'Growth and Usage Dashboard (GUD)',
-					url: 'https://gud.telemetry.mozilla.org/',
-					description: `A tool to visualize growth metrics in a standard way across Mozilla’s products.`
-				},
-				{
-					name: 'Glean Dictionary',
-					url: 'dictionary.telemetry.mozilla.org',
-					description: `A web-based tool that allows you to look up information on all the metrics defined in applications built using Glean, Mozilla's next-generation Telemetry SDK.`
-				},
-				{
-					name: 'Probe Dictionary',
-					url: 'https://probes.telemetry.mozilla.org/',
-					description: `The Probe Dictionary is a web-based tool that allows you to look up information on all the probes defined in Firefox's source code.`
-				}
-			]
-		},
-		{
-			name: 'Docs',
-			items: [
-				{
-					name: 'DTMO',
-					url: 'https://docs.telemetry.mozilla.org/',
-					description: 'Central source for all things Data@Mozilla'
-				},
-				{
-					name: 'Telemetry Docs',
-					url: 'https://mozilla.github.io/glean/book/index.html',
-					description: 'Firefox Source Documentations'
-				},
-				{
-					name: 'Glean SDKs',
-					url: 'https://mozilla.github.io/glean/book/index.html',
-					description: 'Cross-platform Telemetry Libraries'
-				},
-				{
-					name: 'BigQuery-ETL',
-					url: 'https://mozilla.github.io/bigquery-etl/',
-					description: `Mozilla's framework for creating derived datasets and user-defined functions in BigQuery.`
-				},
-				{ name: 'Experimentation', url: 'https://experimenter.info/' },
-				{
-					name: 'Looker Training',
-					url: 'https://mana.mozilla.org/wiki/display/DATA/Looker+Training+Resources'
-				}
-			]
-		}
-	];
+	import { navigations } from './data/navigation';
 </script>
 
-<div class="mzp-c-navigation mzp-is-sticky mzp-has-sticky-navigation">
+<div class="mzp-c-navigation">
 	<div class="mzp-c-navigation-l-content">
 		<div class="mzp-c-navigation-container">
 			<button class="mzp-c-navigation-menu-button" type="button" aria-controls="navigation-demo"
@@ -97,7 +20,7 @@
 								>{navigation.name}</a
 							>
 							{#if navigation.items && navigation.items.length}
-								<div class="mzp-c-menu-panel mzp-c-emphasis-box" id="mzp-c-menu-panel-example">
+								<div class="mzp-c-menu-panel mzp-c-emphasis-box">
 									<div class="mzp-c-menu-panel-container">
 										<div class="mzp-c-menu-panel-content">
 											<ul>
@@ -109,7 +32,8 @@
 									</div>
 								</div>
 							{/if}
-						</li>{/each}
+						</li>
+					{/each}
 				</ul>
 			</nav>
 		</div>

--- a/src/lib/Navigation.svelte
+++ b/src/lib/Navigation.svelte
@@ -1,4 +1,83 @@
 <script>
+	import NavDropdownMenu from '../lib/NavDropdownMenu.svelte';
+
+	const navigations = [
+		{
+			name: 'Tools',
+			items: [
+				{
+					name: 'Looker',
+					url: 'Looker',
+					description: `Mozilla's primary tool for analyzing data.`
+				},
+				{
+					name: 'Glean Aggregated Metrics Dashboard (GLAM)',
+					url: 'glam.telemetry.mozilla.org',
+					description: `An interactive dashboard that examines the distributions of values of specific individual telemetry metrics, over various dimensions.`
+				},
+				{
+					name: 'Experimenter',
+					description: `The central resource for A/B experiments and feature rollouts in Firefox Mobile and Desktop`,
+					url: 'https://experimenter.services.mozilla.com/?ordering=-latest_change&search=&status=Complete&firefox_channel=&firefox_version=&owner=&analysis_owner=&experiment_date_field=&date_range_after=&date_range_before='
+				},
+				{
+					name: 'sql.telemetry.mozilla.org (STMO)',
+					url: 'sql.telemetry.mozilla.org',
+					description: `Mozilla instance of Redash that allows for SQL-based exploratory analysis and visualization / dashboard construction.`
+				},
+				{
+					name: 'Nimbus',
+					url: 'https://experimenter.services.mozilla.com/nimbus/?tab=completed',
+					description: `Firefox's cross-platform experimentation tool.`
+				},
+				{
+					name: 'Growth and Usage Dashboard (GUD)',
+					url: 'https://gud.telemetry.mozilla.org/',
+					description: `A tool to visualize growth metrics in a standard way across Mozilla’s products.`
+				},
+				{
+					name: 'Glean Dictionary',
+					url: 'dictionary.telemetry.mozilla.org',
+					description: `A web-based tool that allows you to look up information on all the metrics defined in applications built using Glean, Mozilla's next-generation Telemetry SDK.`
+				},
+				{
+					name: 'Probe Dictionary',
+					url: 'https://probes.telemetry.mozilla.org/',
+					description: `The Probe Dictionary is a web-based tool that allows you to look up information on all the probes defined in Firefox's source code.`
+				}
+			]
+		},
+		{
+			name: 'Docs',
+			items: [
+				{
+					name: 'DTMO',
+					url: 'https://docs.telemetry.mozilla.org/',
+					description: 'Central source for all things Data@Mozilla'
+				},
+				{
+					name: 'Telemetry Docs',
+					url: 'https://mozilla.github.io/glean/book/index.html',
+					description: 'Firefox Source Documentations'
+				},
+				{
+					name: 'Glean SDKs',
+					url: 'https://mozilla.github.io/glean/book/index.html',
+					description: 'Cross-platform Telemetry Libraries'
+				},
+				{
+					name: 'BigQuery-ETL',
+					url: 'https://mozilla.github.io/bigquery-etl/',
+					description: `Mozilla's framework for creating derived datasets and user-defined functions in BigQuery.`
+				},
+				{ name: 'Experimentation', url: 'https://experimenter.info/' },
+				{
+					name: 'Looker Training',
+					url: 'https://mana.mozilla.org/wiki/display/DATA/Looker+Training+Resources'
+				}
+			]
+		}
+	];
 </script>
 
 <div class="mzp-c-navigation mzp-is-sticky mzp-has-sticky-navigation">
@@ -10,6 +89,29 @@
 			<div class="mzp-c-navigation-logo">
 				<a href="/">data@mozilla</a>
 			</div>
+			<nav class="mzp-c-menu mzp-is-basic">
+				<ul class="mzp-c-menu-category-list">
+					{#each navigations as navigation}
+						<li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">
+							<a class="mzp-c-menu-title disabled" href="/#" aria-haspopup="true"
+								>{navigation.name}</a
+							>
+							{#if navigation.items && navigation.items.length}
+								<div class="mzp-c-menu-panel mzp-c-emphasis-box" id="mzp-c-menu-panel-example">
+									<div class="mzp-c-menu-panel-container">
+										<div class="mzp-c-menu-panel-content">
+											<ul>
+												<li>
+													<NavDropdownMenu items={navigation.items} />
+												</li>
+											</ul>
+										</div>
+									</div>
+								</div>
+							{/if}
+						</li>{/each}
+				</ul>
+			</nav>
 		</div>
 	</div>
 </div>
@@ -38,9 +140,5 @@
 	.disabled {
 		pointer-events: none;
 		cursor: default;
-	}
-	.mzp-c-menu-panel {
-		width: 100%;
-		margin: 2px 1px 2px 30%;
 	}
 </style>

--- a/src/lib/data/navigation.js
+++ b/src/lib/data/navigation.js
@@ -1,0 +1,77 @@
+export const navigations = [
+	{
+		name: 'Tools',
+		items: [
+			{
+				name: 'Looker',
+				url: 'Looker',
+				description: `Mozilla's primary tool for analyzing data.`
+			},
+			{
+				name: 'Glean Aggregated Metrics Dashboard (GLAM)',
+				url: 'glam.telemetry.mozilla.org',
+				description: `An interactive dashboard that examines the distributions of values of specific individual telemetry metrics, over various dimensions.`
+			},
+			{
+				name: 'Experimenter',
+				url: 'https://experimenter.services.mozilla.com/?ordering=-latest_change&search=&status=Complete&firefox_channel=&firefox_version=&owner=&analysis_owner=&experiment_date_field=&date_range_after=&date_range_before=',
+				description: `The central resource for A/B experiments and feature rollouts in Firefox Mobile and Desktop`
+			},
+			{
+				name: 'sql.telemetry.mozilla.org (STMO)',
+				url: 'sql.telemetry.mozilla.org',
+				description: `Mozilla instance of Redash that allows for SQL-based exploratory analysis and visualization / dashboard construction.`
+			},
+			{
+				name: 'Nimbus',
+				url: 'https://experimenter.services.mozilla.com/nimbus/?tab=completed',
+				description: `Firefox's cross-platform experimentation tool.`
+			},
+			{
+				name: 'Growth and Usage Dashboard (GUD)',
+				url: 'https://gud.telemetry.mozilla.org/',
+				description: `A tool to visualize growth metrics in a standard way across Mozilla’s products.`
+			},
+			{
+				name: 'Glean Dictionary',
+				url: 'dictionary.telemetry.mozilla.org',
+				description: `A web-based tool that allows you to look up information on all the metrics defined in applications built using Glean, Mozilla's next-generation Telemetry SDK.`
+			},
+			{
+				name: 'Probe Dictionary',
+				url: 'https://probes.telemetry.mozilla.org/',
+				description: `The Probe Dictionary is a web-based tool that allows you to look up information on all the probes defined in Firefox's source code.`
+			}
+		]
+	},
+	{
+		name: 'Docs',
+		items: [
+			{
+				name: 'DTMO',
+				url: 'https://docs.telemetry.mozilla.org/',
+				description: 'Central source for all things Data@Mozilla'
+			},
+			{
+				name: 'Telemetry Docs',
+				url: 'https://mozilla.github.io/glean/book/index.html',
+				description: 'Firefox Source Documentations'
+			},
+			{
+				name: 'Glean SDKs',
+				url: 'https://mozilla.github.io/glean/book/index.html',
+				description: 'Cross-platform Telemetry Libraries'
+			},
+			{
+				name: 'BigQuery-ETL',
+				url: 'https://mozilla.github.io/bigquery-etl/',
+				description: `Mozilla's framework for creating derived datasets and user-defined functions in BigQuery.`
+			},
+			{ name: 'Experimentation', url: 'https://experimenter.info/' },
+			{
+				name: 'Looker Training',
+				url: 'https://mana.mozilla.org/wiki/display/DATA/Looker+Training+Resources'
+			}
+		]
+	}
+];


### PR DESCRIPTION
This PR adds the first 2 sections to the navigation bar:
- Tools: all the tools we're currently offering to help users work with data
- Docs: supplemental docs to that the data org offers on working with data


![CleanShot 2022-07-25 at 11 15 45@2x](https://user-images.githubusercontent.com/28797553/180813843-0eb24e05-affa-41c3-b577-0c893a2e3180.png)

See the deploy preview below to see what this change looks like.